### PR TITLE
Separate build script and simplified PrgEnv-fluidity module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Don't ignore .gitignore
+!.gitignore
+
+# Emacs backup and autosave files
+*~
+*#
+
+# Object files, etc.
+*.o
+*.mod
+*.a
+*.pyc
+
+# Logs
+*.log
+
+# Generated files
+
+# Data files (input and output)
+*.gz
+
+# Output files and directories

--- a/uk/ac/archer/PrgEnv-fluidity
+++ b/uk/ac/archer/PrgEnv-fluidity
@@ -2,11 +2,12 @@
 #
 # Local module for compiling/running Fluidity on ARCHER
 #
-# To use, run 'module swap PrgEnv-cray PrgEnv-fluidity' after ensuring
-# the location of this file is in MODULEPATH
+# Usage:
 #
-# Note that in addition to this module, anaconda and vtk libraries should
-# be added to LD_LIBRARY_PATH as per methods in the accompanying compile.pbs
+# module use <the directory of this file>
+# module swap PrgEnv-cray PrgEnv-fluidity
+#
+# which assumes you haven't already changed the PrgEnv.
 #
 # Please send any bug reports to Tim Greaves <tim.greaves@imperial.ac.uk>
 #
@@ -19,52 +20,8 @@ conflict PrgEnv-intel
 # Modules to load
 
 module load PrgEnv-gnu
-module swap gcc gcc/4.9.2
 
-module load cray-libsci
-module load cray-tpsl
-module load cray-netcdf
-module load cray-hdf5
-module load cray-petsc
-module load cray-trilinos
-
-module load cmake
-module load boost
-module load vtk
-module unload python
+# The Python modules are needed to get Python at run time.
 module load python-compute
 module load pc-numpy
 #module load pc-scipy
-#module load anaconda
-
-global env
-
-# Tell Fluidity that we're on ARCHER; used by configure
-setenv ARCHER "yes"
-
-# Compiles dynamic loaded libraries.
-setenv CRAYPE_LINK_TYPE "dynamic" 
-setenv CRAY_ADD_RPATH "yes"
-
-setenv CPPFLAGS "-DMPICH_IGNORE_CXX_SEEK"
-
-setenv CC "cc"
-setenv MPICC "cc"
-
-setenv CXX "CC"
-setenv MPICXX "CC"
-
-setenv FC "ftn"
-setenv MPIFC "ftn"
-
-setenv F77 "ftn"
-setenv MPIF77 "ftn"
-
-setenv F90 "ftn"
-setenv MPIF90 "ftn"
-
-# Set up for GNU vtk 
-append-path PATH /work/y07/y07/cse/vtk/5.10.1/GNU/bin
-append-path LD_LIBRARY_PATH /work/y07/y07/cse/vtk/5.10.1/GNU/lib/vtk-5.10
-setenv VTK_LIBS /work/y07/y07/cse/vtk/5.10.1/GNU/lib/vtk-5.10
-setenv VTK_INCLUDE /work/y07/y07/cse/vtk/5.10.1/GNU/include/vtk-5.10

--- a/uk/ac/archer/build.bash
+++ b/uk/ac/archer/build.bash
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+###############################################################################
+#
+# This is an example build script for building Fluidity on Archer, and
+# can be found in the GitHub FluidityProject/buildscripts repository
+# as:
+#
+#  /uk/ac/archer/build.bash
+# 
+# along with the latest PrgEnv-fluidity module and compile and test
+# scripts which will be required for this script to function properly.
+#
+# To check out the build scripts on Archer, start a clean login
+# session, change to a directory on /home or /work, and then run:
+#
+#  git clone https://github.com/FluidityProject/buildscripts.git
+#
+# The resulting buildscripts/uk/ac/archer directory should be used for
+# BUILDSCRIPTS below.
+#
+# To check out Fluidity on Archer, start a clean login session, change
+# to a directory on /work, and then run:
+#
+#  git clone https://github.com/FluidityProject/fluidity.git
+#
+# Edit this script as directed in the comments below.  Change into the
+# fluidity directory and run this script with:
+
+#  <your own buildscripts directory>/build.bash
+#
+# The progress of the build can be monitored in timestamped files of
+# the form:
+#
+#  configure-##########.log
+#  compile-##########.log
+#  unittest-##########.log
+#  serialtest-##########.log
+#  mediumtest-##########.log
+#
+###############################################################################
+
+export TIMESTAMP=`date +%s`
+
+# EDIT REQUIRED: set the project for running the PBS jobs
+export PROJECT="z19-cse"
+
+# EDIT REQUIRED: Set the following to your own buildscripts directory
+export BUILDSCRIPTS=/home/z01/z01/mjf/FluidityProject/buildscripts/uk/ac/archer
+
+# EDIT REQUIRED: Set the following to your own Fluidity directory on
+# /work
+export FLUIDITYDIR=/work/z01/z01/mjf/FluidityProject/fluidity
+
+# Copy the PrgEnv-fluidity module to the Fluidity directory so
+# $BUILDSCRIPTS does not need to be accessed at all at run time
+mkdir -p $FLUIDITYDIR/modulefiles
+cp -p $BUILDSCRIPTS/PrgEnv-fluidity $FLUIDITYDIR/modulefiles
+module use $FLUIDITYDIR/modulefiles
+
+module unload PrgEnv-cray PrgEnv-gnu PrgEnv-intel
+module load PrgEnv-fluidity
+
+# PrgEnv-gnu is loaded by PrgEnv-fluidity
+# python-compute is loaded by PrgEnv-fluidity
+# pc-numpy is loaded by PrgEnv-fluidity
+
+# Change to the Fluidity directory
+cd $FLUIDITYDIR
+
+export CPPFLAGS=""
+export LDFLAGS=""
+export LIBS=""
+
+# Use only Zoltan from Trilinos.  This needs a check that the TPSL
+# version is the same as for cray-petsc.  For cray-petsc/3.6.3.0 the
+# correct version of cray-trilinos is 12.2.1.0 (TPSL 16.03 == TPSL
+# 16.03.1)
+#
+# grep -rI 'TPSL' /opt/cray/petsc/[0-9]*/release_info | uniq
+# /opt/cray/petsc/3.5.2.1/release_info:      TPSL 1.4.3
+# /opt/cray/petsc/3.6.1.0/release_info:      TPSL 1.5.2
+# /opt/cray/petsc/3.6.3.0/release_info:      TPSL 16.03
+# /opt/cray/petsc/3.7.2.0/release_info:      TPSL 16.07.1
+# /opt/cray/petsc/3.7.2.1/release_info:      TPSL 16.07.1
+# /opt/cray/petsc/3.7.4.0/release_info:      TPSL 16.12.1
+#
+# grep -rI 'TPSL' /opt/cray/trilinos/[0-9]*/release_info | uniq
+# /opt/cray/trilinos/11.12.1.0/release_info:      TPSL 1.4.3
+# /opt/cray/trilinos/11.12.1.5/release_info:      TPSL 1.5.2
+# /opt/cray/trilinos/12.2.1.0/release_info:      TPSL 16.03.1
+# /opt/cray/trilinos/12.6.3.1/release_info:      TPSL 16.07.1
+# /opt/cray/trilinos/12.6.3.2/release_info:      TPSL 16.07.1
+# /opt/cray/trilinos/12.8.1.0/release_info:      TPSL 16.12.1
+#
+# If using the installed Zoltan causes problems (it shouldn't), then
+# Zoltan will need to be built separately
+module load cray-trilinos/12.2.1.0
+CPPFLAGS="$CPPFLAGS -I$CRAY_TRILINOS_PREFIX_DIR/include"
+LDFLAGS="$LDFLAGS -Wl,-rpath=$CRAY_TRILINOS_PREFIX_DIR/lib"
+LIBS="$LIBS -L$CRAY_TRILINOS_PREFIX_DIR/lib -lzoltan"
+module unload cray-trilinos
+
+module load cray-hdf5
+module load cray-netcdf
+# cray-petsc/3.6.3.0 needs cray-mpich >= 7.3 (all the other cray-petsc just need cray-mpich >= 7.0)
+# cray-petsc/3.6.3.0 needs cray-tpsl >= 16.03.1 (and has been built with 16.03 == 16.03.1)
+module switch cray-mpich/7.3.2
+module load cray-tpsl/16.03.1
+module load cray-petsc/3.6.3.0
+module load cmake
+module load boost
+module load vtk
+
+module list > configure-${TIMESTAMP}.log 2>&1
+
+export PATH=$PATH:$FLUIDITYDIR/bin
+export PYTHONPATH=$PYTHONPATH:$FLUIDITYDIR/python
+
+# Tell Fluidity that we're on ARCHER; used by configure
+export ARCHER="yes"
+
+# Compile dynamic loaded libraries and fix the library paths to search
+export CRAYPE_LINK_TYPE="dynamic" 
+export CRAY_ADD_RPATH="yes"
+
+CPPFLAGS="$CPPFLAGS -DMPICH_IGNORE_CXX_SEEK"
+
+export CC="cc"
+export MPICC="cc"
+export CXX="CC"
+export MPICXX="CC"
+export FC="ftn"
+export MPIFC="ftn"
+export F77="ftn"
+export MPIF77="ftn"
+export F90="ftn"
+export MPIF90="ftn"
+
+echo "CPPFLAGS=$CPPFLAGS" >> configure-${TIMESTAMP}.log
+echo "LIBS=$LIBS" >> configure-${TIMESTAMP}.log
+
+# The configure step needs to run on a login node (which is almost
+# identical to a compute node) and the compilation should be run on a
+# PP node because it takes a long time.  compile.pbs has "#PBS -V", so
+# it will get all the environment set up by this script.
+if ./configure --enable-2d-adaptivity >> configure-${TIMESTAMP}.log 2>&1; then
+    job1=$(qsub -A $PROJECT $BUILDSCRIPTS/compile.pbs)
+else
+    echo "configure_failed"
+    exit 1
+fi
+
+# Test aren't working yet
+#
+# Tests are meant to test the run time setup, so only pass the
+# time-stamp and the Fluidity directory.
+#qsub -W depend=afterok:$job1 -A $PROJECT -v TIMESTAMP,FLUIDITYDIR $BUILDSCRIPTS/unittest.pbs
+#qsub -W depend=afterok:$job1 -A $PROJECT -v TIMESTAMP,FLUIDITYDIR $BUILDSCRIPTS/serialtest.pbs
+#qsub -W depend=afterok:$job1 -A $PROJECT -v TIMESTAMP,FLUIDITYDIR $BUILDSCRIPTS/mediumtest.pbs
+
+exit 0

--- a/uk/ac/archer/compile.pbs
+++ b/uk/ac/archer/compile.pbs
@@ -6,56 +6,48 @@
 # found in the GitHub FluidityProject/buildscripts repository as:
 #
 #     /uk/ac/archer/compile.pbs
-# 
-# along with the latest PrgEnv-fluidity module which will be required for this
-# script to function properly.
 #
-# To check out Fluidity on archer, start a clean login session, change to your
-# work directory, and then run:
+# This script is submitted by build.bash to compile Fluidity using the
+# configuration set up by build.bash
 #
-#  git clone https://github.com/FluidityProject/fluidity.git
-#
-# Change into the resulting fluidity/ directory, place this script in it, edit
-# as directed in the comments below, and submit it with:
-#
-#  qsub compile.pbs
-#
-# The progress of the compilation can be monitored in a timestamped file of the
-# form:
+# The progress of the compilation can be monitored in a timestamped
+# file of the form:
 #
 #  compile-##########.log
 #
 ###############################################################################
 
-#PBS -l walltime=01:00:00
 #PBS -N compile
-#PBS -l select=1
+#PBS -l select=serial=true:ncpus=8
+#PBS -l walltime=1:00:00
+#PBS -V
 
-# EDIT REQUIRED: set the project this job should be billed to 
+# Make sure any symbolic links are resolved to absolute path
+export PBS_O_WORKDIR=$(readlink -f $PBS_O_WORKDIR)
 
-#PBS -A projectcode
+# Change to the directory that the job was submitted from
+cd $PBS_O_WORKDIR
 
-export TIMESTAMP=`date +%s`
+# The configuration has to be done already, on the login nodes, and
+# the PBS -V directive (see above) gets the environment that has been
+# set up.  The compilation takes about 30 minutes ('make -j 8') on a
+# serial node.
 
-# EDIT REQUIRED: Set the following for the location where you have put the 
-#                  PrgEnv-fluidity module
-#
-export MODULEPATH=$MODULEPATH:$HOME/privatemodules
-module swap PrgEnv-cray PrgEnv-fluidity
+# The compile step is run on the serial nodes because the compile
+# takes so long, and some optimisation steps may take so long that the
+# /tmp directory is emptied by the system during the optimisations,
+# giving 'file not found' errors.  This seems to be occurring on the
+# serial nodes as well now so TMPDIR is set; this may affect Cray
+# Fortran OPEN statements for scratch files.
+mkdir -p tmp
+export TMPDIR=$PWD/tmp
 
-# EDIT REQUIRED: Set the following for your own work directory and fluidity
-#                  build location
-#
-export WORK=/work/y07/y07/fluidity/build
-export FLUIDITYDIR=$WORK/fluidity
-export PATH=$PATH:$FLUIDITYDIR/bin
-export PYTHONPATH=$PYTHONPATH:$FLUIDITYDIR/python
+make clean > compile-${TIMESTAMP}.log 2>&1
+# The j value MUST be the same as the ncpus value in the #PBS -l
+# select line.
+make -j 8 >> compile-${TIMESTAMP}.log 2>&1
+make -j 8 fltools >> compile-${TIMESTAMP}.log 2>&1
+#make -j 8 build_unittest >> compile-${TIMESTAMP}.log 2>&1
 
-# Change to the Fluidity source directory
-cd $FLUIDITYDIR
-
-./configure --enable-2d-adaptivity 2>&1 >>compile-${TIMESTAMP}.log 
-make clean 2>&1 >>compile-${TIMESTAMP}.log 
-make -j 2>&1 >>compile-${TIMESTAMP}.log 
-make -j fltools 2>&1 >>compile-${TIMESTAMP}.log 
-
+unset TMPDIR
+rm -rf tmp

--- a/uk/ac/archer/mediumtest.pbs
+++ b/uk/ac/archer/mediumtest.pbs
@@ -1,0 +1,49 @@
+#!/bin/bash --login
+
+###############################################################################
+#
+# This is an example PBS script for testing Fluidity on Archer, and
+# can be found in the GitHub FluidityProject/buildscripts repository
+# as:
+#
+#     /uk/ac/archer/mediumtest.pbs
+#
+# This script is submitted by build.bash to test Fluidity.
+#
+# The progress of the tests can be monitored in a timestamped
+# file of the form:
+#
+#  mediumtest-##########.log
+#
+###############################################################################
+
+#PBS -N mediumtest
+#PBS -l select=1
+#PBS -l walltime=24:00:00
+
+# Make sure any symbolic links are resolved to absolute path
+export PBS_O_WORKDIR=$(readlink -f $PBS_O_WORKDIR)
+
+# Change to the directory that the job was submitted from
+cd $PBS_O_WORKDIR
+
+# FLUIDITYDIR comes from the environment passed in using qsub -v
+module use $FLUIDITYDIR/modulefiles
+module unload PrgEnv-cray PrgEnv-gnu PrgEnv-intel
+module load PrgEnv-fluidity
+export PATH=$PATH:$FLUIDITYDIR/bin
+export PYTHONPATH=$PYTHONPATH:$FLUIDITYDIR/python
+
+# The tests takes about ?? hours on a compute node.
+
+mkdir -p tmp
+export TMPDIR=$PWD/tmp
+
+# Parallel tests use 'mpiexec'
+alias mpiexec=aprun
+
+# TIMESTAMP comes from the environment passed in using qsub -v
+make mediumtest > mediumtest-${TIMESTAMP}.log 2>&1
+
+unset TMPDIR
+rm -rf tmp

--- a/uk/ac/archer/serialtest.pbs
+++ b/uk/ac/archer/serialtest.pbs
@@ -1,0 +1,46 @@
+#!/bin/bash --login
+
+###############################################################################
+#
+# This is an example PBS script for testing Fluidity on Archer, and
+# can be found in the GitHub FluidityProject/buildscripts repository
+# as:
+#
+#     /uk/ac/archer/serialtest.pbs
+#
+# This script is submitted by build.bash to test Fluidity.
+#
+# The progress of the tests can be monitored in a timestamped
+# file of the form:
+#
+#  serialtest-##########.log
+#
+###############################################################################
+
+#PBS -N serialtest
+#PBS -l select=1
+#PBS -l walltime=24:00:00
+
+# Make sure any symbolic links are resolved to absolute path
+export PBS_O_WORKDIR=$(readlink -f $PBS_O_WORKDIR)
+
+# Change to the directory that the job was submitted from
+cd $PBS_O_WORKDIR
+
+# FLUIDITYDIR comes from the environment passed in using qsub -v
+module use $FLUIDITYDIR/modulefiles
+module unload PrgEnv-cray PrgEnv-gnu PrgEnv-intel
+module load PrgEnv-fluidity
+export PATH=$PATH:$FLUIDITYDIR/bin
+export PYTHONPATH=$PYTHONPATH:$FLUIDITYDIR/python
+
+# The tests takes about ?? hours on a compute node.
+
+mkdir -p tmp
+export TMPDIR=$PWD/tmp
+
+# TIMESTAMP comes from the environment passed in using qsub -v
+aprun -n 1 make serialtest > serialtest-${TIMESTAMP}.log 2>&1
+
+unset TMPDIR
+rm -rf tmp

--- a/uk/ac/archer/top_hat.pbs
+++ b/uk/ac/archer/top_hat.pbs
@@ -8,7 +8,7 @@
 #     /uk/ac/archer/top_hat.pbs
 #
 # That directory also contains a build script for Fluidity on Archer,
-# along with the lateѕt PrgEnv-fluidity module which will need to be
+# along with the latest PrgEnv-fluidity module which will need to be
 # present as described below for this script to function.
 #
 # It is intended to be a drop-in script for the examples/top_hat/
@@ -28,31 +28,31 @@
 #PBS -l select=1
 
 # EDIT REQUIRED: set the project this job should be billed to 
+#PBS -A z19-cse
 
-#PBS -A project
+# EDIT REQUIRED: Set the following to your own Fluidity install
+# directory
+export FLUIDITYDIR=/work/z01/z01/mjf/FluidityProject/fluidity
 
-# Change to directory that the job was submitted from
+# Make sure any symbolic links are resolved to absolute path
+export PBS_O_WORKDIR=$(readlink -f $PBS_O_WORKDIR)
+
+# Change to the directory that the job was submitted from
 cd $PBS_O_WORKDIR
 
-# EDIT REQUIRED: Set the following for your own work directory and fluidity
-#                  build location
-#
-export WORK=/work/project/project/username
-export FLUIDITYDIR=$WORK/fluidity
-
-export PATH=$PATH:$FLUIDITYDIR/bin:/work/y07/y07/cse/vtk/5.10.1/GNU/bin
+module use $FLUIDITYDIR/modulefiles
+module unload PrgEnv-cray PrgEnv-gnu PrgEnv-intel
+module load PrgEnv-fluidity
+export PATH=$PATH:$FLUIDITYDIR/bin
 export PYTHONPATH=$PYTHONPATH:$FLUIDITYDIR/python
-export MODULEPATH=$MODULEPATH:$HOME/privatemodules
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/y07/y07/cse/anaconda/2.2.0-python2/lib/:/work/y07/y07/cse/vtk/5.10.1/GNU/lib/vtk-5.10/
-module swap PrgEnv-cray PrgEnv-fluidity
 
 # NOTE: To use hyperthreading, pass '-j 2' to aprun
 
-aprun -n 1 interval --dx=0.025 --reverse 0 3 line
+time aprun -n 1 interval --dx=0.025 --reverse 0 3 line
 
 echo **********Running the Continuous Galerkin version of this example:
-aprun -n 1 fluidity -v2 -l top_hat_cg.flml
+time aprun -n 1 fluidity -v2 -l $FLUIDITYDIR/examples/top_hat/top_hat_cg.flml
 echo **********Running the Discontinuous Galerkin version of this example:
-aprun -n 1 fluidity -v2 -l top_hat_dg.flml
+time aprun -n 1 fluidity -v2 -l $FLUIDITYDIR/examples/top_hat/top_hat_dg.flml
 echo **********Running the Control Volumes version of this example:
-aprun -n 1 fluidity -v2 -l top_hat_cv.flml
+time aprun -n 1 fluidity -v2 -l $FLUIDITYDIR/examples/top_hat/top_hat_cv.flml

--- a/uk/ac/archer/unittest.pbs
+++ b/uk/ac/archer/unittest.pbs
@@ -1,0 +1,46 @@
+#!/bin/bash --login
+
+###############################################################################
+#
+# This is an example PBS script for testing Fluidity on Archer, and
+# can be found in the GitHub FluidityProject/buildscripts repository
+# as:
+#
+#     /uk/ac/archer/unittest.pbs
+#
+# This script is submitted by build.bash to test Fluidity.
+#
+# The progress of the tests can be monitored in a timestamped
+# file of the form:
+#
+#  unittest-##########.log
+#
+###############################################################################
+
+#PBS -N unittest
+#PBS -l select=1
+#PBS -l walltime=24:00:00
+
+# Make sure any symbolic links are resolved to absolute path
+export PBS_O_WORKDIR=$(readlink -f $PBS_O_WORKDIR)
+
+# Change to the directory that the job was submitted from
+cd $PBS_O_WORKDIR
+
+# FLUIDITYDIR comes from the environment passed in using qsub -v
+module use $FLUIDITYDIR/modulefiles
+module unload PrgEnv-cray PrgEnv-gnu PrgEnv-intel
+module load PrgEnv-fluidity
+export PATH=$PATH:$FLUIDITYDIR/bin
+export PYTHONPATH=$PYTHONPATH:$FLUIDITYDIR/python
+
+# The tests takes about ?? hours on a compute node.
+
+mkdir -p tmp
+export TMPDIR=$PWD/tmp
+
+# TIMESTAMP comes from the environment passed in using qsub -v
+aprun -n 1 make unittest > unittest-${TIMESTAMP}.log 2>&1
+
+unset TMPDIR
+rm -rf tmp


### PR DESCRIPTION
Do the build with a bash script to configure and a PBS script to
compile.  Using RPATH/RUNPATH in the libraries and executables means
the the PrgEnv-fluidity module is simplified.  The Zoltan library from
the cray-trilinos module that matches the cray-petsc module is used
(the other Trilinos packages are not loaded).

Some test scripts are available but have not been tested.

PETSc 3.6.3.0 is used